### PR TITLE
Update the documentation on the Kopis drone

### DIFF
--- a/docs/source/vehicles/kopis.rst
+++ b/docs/source/vehicles/kopis.rst
@@ -66,7 +66,7 @@ Arena Setup
      - CineWhoop3-11
      - pixracer
      - Quadrotor
-     - ✔️
+     - ❌
      - KakuteH7
      - TBD
    * - 12
@@ -75,7 +75,7 @@ Arena Setup
      - CineWhoop3-12
      - pixracer
      - Quadrotor
-     - ✔️
+     - ❌
      - KakuteH7
      - TBD
 
@@ -142,7 +142,7 @@ In order to replicate the Kopis setup adopted on the Taguspark Flight Arena, the
 Kakute H7 Setup
 ---------------
 
-1. Configure the Kakute H7 v2 flight controller with PX4 firmware (v1.14.2), by following the instructions on the `PX4 documentation <https://docs.px4.io/main/en/flight_controller/kakuteh7v2.html>`__. Start by cloning and compiling the PX4 firmware repository:
+1. Configure the KakuteH7/KakuteH7v2 flight controller with PX4 firmware (v1.14.2), by following the instructions on the `PX4 documentation <https://docs.px4.io/main/en/flight_controller/kakuteh7v2.html>`__. Start by cloning and compiling the PX4 firmware repository:
 
   .. code:: bash
 
@@ -151,39 +151,44 @@ Kakute H7 Setup
       cd PX4-Autopilot
       git checkout v1.14.2
 
-and now, compile the bootloader and the firmware for the flight controller. For the KakuteH7, use the commands
+2. Compile the bootloader and the firmware for the flight controller. Use the commands depending on the board version (KakuteH7/KakuteH7v2):
 
   .. code:: bash
 
-      # Compile the bootloader and the firmware for the KakuteH7
+      # Use these commands to compile the bootloader and the firmware for the KakuteH7
       make holybro_kakuteh7_bootloader
       make holybro_kakuteh7_default
 
-and for the KakuteH7v2, use
-
-  .. code:: bash
-
-      # Compile the bootloader and the firmware for the KakuteH7v2
+      # Use these commands to compile the bootloader and the firmware for the KakuteH7v2
       make holybro_kakuteh7v2_bootloader
       make holybro_kakuteh7v2_default
 
-2. Install DFU-Util to flash the bootloader into the KakuteH7/KakuteH7v2:
+2. Install DFU-Util to flash the bootloader into the Kakute board:
 
   .. code:: bash
 
       sudo apt-get install dfu-util
 
-3. Connect the Kakute to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute H7 v2:
+3. Connect the Kakute to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute:
 
   .. code:: bash
 
+      # Use these commands for the KakuteH7
+      dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/holybro_kakuteh7_bootloader/holybro_kakuteh7_bootloader.bin
+      dfu-util -a 0 --dfuse-address 0x08000000 -D  build/holybro_kakuteh7_bootloader/holybro_kakuteh7_bootloader.bin
+
+      # Use these commands for the KakuteH7v2
       dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
       dfu-util -a 0 --dfuse-address 0x08000000 -D  build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
 
-4. After flashing the bootloader, reboot the Kakute H7 v2 without pressing the button. Upload the firmware by using QGroundControl and following the instructions on the `PX4 documentation <https://docs.px4.io/main/en/flight_controller/kakuteh7v2.html>`__ or run the command.
+4. After flashing the bootloader, reboot the Kakute without pressing the button. Upload the firmware by using QGroundControl or run one of the following commands
 
   .. code:: bash
+    
+    # Use this command for the KakuteH7
+    make holybro_kakuteh7_default upload
 
+    # Use this command for the KakuteH7v2
     make holybro_kakuteh7v2_default upload
 
 5. After having the firmware installed, connect the Kakute to the computer and open QGroundControl.

--- a/docs/source/vehicles/kopis.rst
+++ b/docs/source/vehicles/kopis.rst
@@ -1,7 +1,7 @@
 Kopis Drone Setup
 =================
 
-In this section, we describe the setup of the Kopis Cinewhoop 3" drone. Equipped with a Kakute H7 v2 flight controller and an ESP8266 module for communication with an offboard computer, the Kopis Cinewhoop 3" is a small drone that enables the fast prototyping and testing of control algoritms in dedicated flight arenas such as the :ref:`Taguspark Flight Arena`.
+In this section, we describe the setup of the Kopis Cinewhoop 3" drone. Equipped with either a KakuteH7 or a KakuteH7v2 flight controller and an ESP8266 module for communication with an offboard computer, the Kopis Cinewhoop 3" is a small drone that enables the fast prototyping and testing of control algoritms in dedicated flight arenas such as the :ref:`Taguspark Flight Arena`.
 
 .. image:: https://holybro.com/cdn/shop/products/30064_2_1800x1800.jpg?v=1647227793
   :width: 600
@@ -12,7 +12,7 @@ Arena Setup
 -----------
 
 .. list-table:: ID, IPs and Mavlink Ports and other information
-   :widths: 5 15 5 15 10 10 10 10
+   :widths: 5 15 5 15 10 10 5 10 10
    :header-rows: 1
     
    * - ID
@@ -22,6 +22,7 @@ Arena Setup
      - AP Password
      - Station SSID
      - Status
+     - Kakute version
      - Config File
    * - 7
      - 192.168.1.247
@@ -30,6 +31,7 @@ Arena Setup
      - pixracer
      - Quadrotor
      - ❌/✔️
+     - KakuteH7v2
      - `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_7.params>`__
    * - 8
      - 192.168.1.248
@@ -38,6 +40,7 @@ Arena Setup
      - pixracer
      - Quadrotor
      - ✔️
+     - KakuteH7v2
      - `kopis8.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_8.params>`__
    * - 9
      - 192.168.1.249
@@ -46,6 +49,7 @@ Arena Setup
      - pixracer
      - Quadrotor
      - ✔️
+     - KakuteH7v2
      - `kopis9.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_9.params>`__
    * - 10
      - 192.168.1.250
@@ -54,7 +58,26 @@ Arena Setup
      - pixracer
      - Quadrotor
      - ✔️
+     - KakuteH7v2
      - `kopis10.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_10.params>`__
+   * - 11
+     - 192.168.1.251
+     - 15011
+     - CineWhoop3-11
+     - pixracer
+     - Quadrotor
+     - ✔️
+     - KakuteH7
+     - TBD
+   * - 12
+     - 192.168.1.252
+     - 15012
+     - CineWhoop3-12
+     - pixracer
+     - Quadrotor
+     - ✔️
+     - KakuteH7
+     - TBD
 
 The vehicles are configured to connect to the station network if the Statis SSID is detected. Otherwise, the vehicles will create an AP with the AP SSID and AP Password, according to the table above.
 
@@ -119,7 +142,7 @@ In order to replicate the Kopis setup adopted on the Taguspark Flight Arena, the
 Kakute H7 Setup
 ---------------
 
-1. Configure the Kakute H7 v2 flight controller with PX4 firmware (v1.14.2), by following the instructions on the `PX4 documentation <https://docs.px4.io/main/en/flight_controller/kakuteh7v2.html>`__. Start by cloning and compiling the PX4 firmware repository and running the following commands:
+1. Configure the Kakute H7 v2 flight controller with PX4 firmware (v1.14.2), by following the instructions on the `PX4 documentation <https://docs.px4.io/main/en/flight_controller/kakuteh7v2.html>`__. Start by cloning and compiling the PX4 firmware repository:
 
   .. code:: bash
 
@@ -128,19 +151,29 @@ Kakute H7 Setup
       cd PX4-Autopilot
       git checkout v1.14.2
 
-      # Compile the bootloader for the board
-      make holybro_kakuteh7v2_bootloader
+and now, compile the bootloader and the firmware for the flight controller. For the KakuteH7, use the commands
 
-      # Compile the firmware for the board
+  .. code:: bash
+
+      # Compile the bootloader and the firmware for the KakuteH7
+      make holybro_kakuteh7_bootloader
+      make holybro_kakuteh7_default
+
+and for the KakuteH7v2, use
+
+  .. code:: bash
+
+      # Compile the bootloader and the firmware for the KakuteH7v2
+      make holybro_kakuteh7v2_bootloader
       make holybro_kakuteh7v2_default
 
-2. Install DFU-Util to flash the bootloader into the Kakute H7 v2:
+2. Install DFU-Util to flash the bootloader into the KakuteH7/KakuteH7v2:
 
   .. code:: bash
 
       sudo apt-get install dfu-util
 
-3. Connect the Kakute H7 v2 to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute H7 v2:
+3. Connect the Kakute to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute H7 v2:
 
   .. code:: bash
 
@@ -153,7 +186,7 @@ Kakute H7 Setup
 
     make holybro_kakuteh7v2_default upload
 
-5. After having the firmware installed, connect the Kakute H7 v2 to the computer and open QGroundControl.
+5. After having the firmware installed, connect the Kakute to the computer and open QGroundControl.
 
 6. Load the Kopis parameters from the configuration file `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_7.params>`__.
 

--- a/docs/source/vehicles/kopis.rst
+++ b/docs/source/vehicles/kopis.rst
@@ -139,8 +139,56 @@ In order to replicate the Kopis setup adopted on the Taguspark Flight Arena, the
 * 1x `Time-of-flight sensor <https://holybro.com/collections/sensors/products/st-vl53l1x-lidar>`__
 * 1x `Optical flow sensor <https://holybro.com/products/pmw3901-optical-flow-sensor>`__
 
-Kakute H7 Setup
----------------
+Kakute Flight Controller Setup
+------------------------------
+
+Two different approaches are considered to setup the Kakute flight controller: 1) using our custom prebuilt images (recommended), or 2) compiling PX4 from source.
+
+**Option 1 - Using Custom prebuilt binaries
+
+We provide some prebuilt binaries of the PX4-autopilot source code (release v1.14), with some minor corrections and modifications for our specific use.
+To flash these custom images, proceed as follows.
+
+1. Install DFU-Util to flash the bootloader into the Kakute board:
+
+  .. code:: bash
+
+      sudo apt-get install dfu-util
+
+2. Open a terminal, and download the custom images into your computer:
+
+
+3. Connect the Kakute to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute:
+
+  .. code:: bash
+
+      # Use these commands for the KakuteH7
+      dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/holybro_kakuteh7_bootloader/holybro_kakuteh7_bootloader.bin
+      dfu-util -a 0 --dfuse-address 0x08000000 -D  build/holybro_kakuteh7_bootloader/holybro_kakuteh7_bootloader.bin
+
+      # Use these commands for the KakuteH7v2
+      dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
+      dfu-util -a 0 --dfuse-address 0x08000000 -D  build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
+
+5. After flashing the bootloader, reboot the Kakute without pressing the button. Upload the firmware by using QGroundControl or run one of the following commands
+
+  .. code:: bash
+    
+    # Use this command for the KakuteH7
+    make holybro_kakuteh7_default upload
+
+    # Use this command for the KakuteH7v2
+    make holybro_kakuteh7v2_default upload
+
+6. After having the firmware installed, connect the Kakute to the computer and open QGroundControl.
+
+7. Load the Kopis parameters from the configuration file `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_7.params>`__.
+
+8. Change the MAV_SYS_ID parameter to the ID of the new vehicle.
+
+
+
+**Option 2 - Compiling PX4 from source**
 
 1. Configure the KakuteH7/KakuteH7v2 flight controller with PX4 firmware (v1.14.2), by following the instructions on the `PX4 documentation <https://docs.px4.io/main/en/flight_controller/kakuteh7v2.html>`__. Start by cloning and compiling the PX4 firmware repository:
 
@@ -163,13 +211,13 @@ Kakute H7 Setup
       make holybro_kakuteh7v2_bootloader
       make holybro_kakuteh7v2_default
 
-2. Install DFU-Util to flash the bootloader into the Kakute board:
+3. Install DFU-Util to flash the bootloader into the Kakute board:
 
   .. code:: bash
 
       sudo apt-get install dfu-util
 
-3. Connect the Kakute to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute:
+4. Connect the Kakute to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute:
 
   .. code:: bash
 
@@ -181,7 +229,7 @@ Kakute H7 Setup
       dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
       dfu-util -a 0 --dfuse-address 0x08000000 -D  build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
 
-4. After flashing the bootloader, reboot the Kakute without pressing the button. Upload the firmware by using QGroundControl or run one of the following commands
+5. After flashing the bootloader, reboot the Kakute without pressing the button. Upload the firmware by using QGroundControl or run one of the following commands
 
   .. code:: bash
     
@@ -191,11 +239,11 @@ Kakute H7 Setup
     # Use this command for the KakuteH7v2
     make holybro_kakuteh7v2_default upload
 
-5. After having the firmware installed, connect the Kakute to the computer and open QGroundControl.
+6. After having the firmware installed, connect the Kakute to the computer and open QGroundControl.
 
-6. Load the Kopis parameters from the configuration file `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_7.params>`__.
+7. Load the Kopis parameters from the configuration file `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_7.params>`__.
 
-7. Change the MAV_SYS_ID parameter to the ID of the new vehicle.
+8. Change the MAV_SYS_ID parameter to the ID of the new vehicle.
 
 ESP Configuration
 -----------------

--- a/docs/source/vehicles/kopis.rst
+++ b/docs/source/vehicles/kopis.rst
@@ -32,7 +32,7 @@ Arena Setup
      - Quadrotor
      - ❌/✔️
      - KakuteH7v2
-     - `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_7.params>`__
+     - `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/Parameters/kopis_7.params>`__
    * - 8
      - 192.168.1.248
      - 15008
@@ -41,7 +41,7 @@ Arena Setup
      - Quadrotor
      - ✔️
      - KakuteH7v2
-     - `kopis8.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_8.params>`__
+     - `kopis8.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/Parameters/kopis_8.params>`__
    * - 9
      - 192.168.1.249
      - 15009
@@ -50,7 +50,7 @@ Arena Setup
      - Quadrotor
      - ✔️
      - KakuteH7v2
-     - `kopis9.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_9.params>`__
+     - `kopis9.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/Parameters/kopis_9.params>`__
    * - 10
      - 192.168.1.250
      - 15010
@@ -59,7 +59,7 @@ Arena Setup
      - Quadrotor
      - ✔️
      - KakuteH7v2
-     - `kopis10.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_10.params>`__
+     - `kopis10.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/Parameters/kopis_10.params>`__
    * - 11
      - 192.168.1.251
      - 15011
@@ -142,11 +142,11 @@ In order to replicate the Kopis setup adopted on the Taguspark Flight Arena, the
 Kakute Flight Controller Setup
 ------------------------------
 
-Two different approaches are considered to setup the Kakute flight controller: 1) using our custom prebuilt images (recommended), or 2) compiling PX4 from source.
+Two different approaches are considered to setup the Kakute flight controller: 1) using our custom precompiled binaries (recommended), or 2) compiling PX4 from source.
 
-**Option 1 - Using Custom prebuilt binaries**
+**Option 1 - Using custom precompiled binaries (recommended)**
 
-We provide some prebuilt binaries of the PX4-autopilot source code (release v1.14), with some minor corrections and modifications for our specific use.
+We provide some precompiled binaries of the PX4-autopilot source code (release v1.14.2), with some minor corrections and modifications for our specific use case.
 To flash these custom images, proceed as follows.
 
 1. Install DFU-Util to flash the bootloader into the Kakute board:
@@ -155,34 +155,33 @@ To flash these custom images, proceed as follows.
 
       sudo apt-get install dfu-util
 
-2. Open a terminal, and download the custom images into your computer:
+2. Open a terminal, and download the bootloader images into your computer, depending on the required board version. Do not close the terminal once you finish.
 
+  .. code:: bash
+    
+      # Use these command for the KakuteH7
+      wget "https://github.com/PegasusResearch/drone_configs/raw/refs/heads/main/Kopis/PX4-Autopilot(v1.14.2)/KakuteH7/holybro_kakuteh7_bootloader.bin"
+
+      # Use this command for the KakuteH7v2
+      wget "https://github.com/PegasusResearch/drone_configs/raw/refs/heads/main/Kopis/PX4-Autopilot(v1.14.2)/KakuteH7v2/holybro_kakuteh7v2_bootloader.bin"
 
 3. Connect the Kakute to the computer using a USB cable and put the board in bootloader mode by pressing the button on the board while connecting the cable. Flash the bootloader into the Kakute:
 
   .. code:: bash
 
       # Use these commands for the KakuteH7
-      dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/holybro_kakuteh7_bootloader/holybro_kakuteh7_bootloader.bin
-      dfu-util -a 0 --dfuse-address 0x08000000 -D  build/holybro_kakuteh7_bootloader/holybro_kakuteh7_bootloader.bin
+      dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D ./holybro_kakuteh7_bootloader.bin
+      dfu-util -a 0 --dfuse-address 0x08000000 -D  ./holybro_kakuteh7_bootloader.bin
 
       # Use these commands for the KakuteH7v2
-      dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
-      dfu-util -a 0 --dfuse-address 0x08000000 -D  build/holybro_kakuteh7v2_bootloader/holybro_kakuteh7v2_bootloader.bin
+      dfu-util -a 0 --dfuse-address 0x08000000:force:mass-erase:leave -D ./holybro_kakuteh7v2_bootloader.bin
+      dfu-util -a 0 --dfuse-address 0x08000000 -D  ./holybro_kakuteh7v2_bootloader.bin
 
-5. After flashing the bootloader, reboot the Kakute without pressing the button. Upload the firmware by using QGroundControl or run one of the following commands
-
-  .. code:: bash
-    
-    # Use this command for the KakuteH7
-    make holybro_kakuteh7_default upload
-
-    # Use this command for the KakuteH7v2
-    make holybro_kakuteh7v2_default upload
+5. After flashing the bootloader, reboot the Kakute without pressing the button. Download the firmware for the `KakuteH7 <https://github.com/PegasusResearch/drone_configs/raw/refs/heads/main/Kopis/PX4-Autopilot(v1.14.2)/KakuteH7/holybro_kakuteh7_default.px4>`__ or for the `KakuteH7v2 <https://github.com/PegasusResearch/drone_configs/raw/refs/heads/main/Kopis/PX4-Autopilot(v1.14.2)/KakuteH7v2/holybro_kakuteh7v2_default.px4>`__ and load it to the board using QGroundControl (instrutions `here <https://docs.px4.io/main/en/config/firmware.html#loading-firmware>`__). Note that you want to install a custom version (specific instructions `here <https://docs.px4.io/main/en/config/firmware.html#installing-px4-main-beta-or-custom-firmware>`__).
 
 6. After having the firmware installed, connect the Kakute to the computer and open QGroundControl.
 
-7. Load the Kopis parameters from the configuration file `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/kopis_7.params>`__.
+7. Load the Kopis parameters from the configuration file `kopis7.params <https://github.com/PegasusResearch/drone_configs/blob/main/Kopis/Parameters/kopis_7.params>`__.
 
 8. Change the MAV_SYS_ID parameter to the ID of the new vehicle.
 

--- a/docs/source/vehicles/kopis.rst
+++ b/docs/source/vehicles/kopis.rst
@@ -144,7 +144,7 @@ Kakute Flight Controller Setup
 
 Two different approaches are considered to setup the Kakute flight controller: 1) using our custom prebuilt images (recommended), or 2) compiling PX4 from source.
 
-**Option 1 - Using Custom prebuilt binaries
+**Option 1 - Using Custom prebuilt binaries**
 
 We provide some prebuilt binaries of the PX4-autopilot source code (release v1.14), with some minor corrections and modifications for our specific use.
 To flash these custom images, proceed as follows.


### PR DESCRIPTION
Update the instructions considering that now we will have drones with both the KakuteH7 and the KakuteH7v2 flight controllers.